### PR TITLE
COM-1554 fix incoherent error message when empty mfa code is submitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "franken-srp-react",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "react component for franken-srp",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/srp.ts
+++ b/src/hooks/srp.ts
@@ -77,7 +77,7 @@ export const useSRP = ({
   const next = async ({ code }: { code?: string }) => {
     if (generator) {
       setLoading(true);
-      const result = await (code ? generator.next(code) : generator.next());
+      const result = await generator.next(code || '');
       setLoading(false);
       setStep(result.value);
     }

--- a/test/mfa.spec.tsx
+++ b/test/mfa.spec.tsx
@@ -91,6 +91,35 @@ describe("sms mfa", () => {
     expect(onError).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toHaveTextContent(/success/);
   });
+
+  it("shows error when no code is entered", async () => {
+    render(<Login {...defaultProps} customGenerator={mockGenerators.smsMfa} />);
+    await fillAndClick(
+      { [labels.username]: username, [labels.password]: password },
+      labels.signIn
+    );
+
+    expect(screen.getByLabelText(labels.smsMFA)).toHaveValue("");
+    await fillAndClick({}, labels.verify);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/incorrect/);
+    expect(screen.getByLabelText(labels.smsMFA)).toHaveValue("");
+    await fillAndClick({ [labels.smsMFA]: mfaCode }, labels.verify);
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokens: expect.objectContaining({
+          accessToken: "ACCESS_TOKEN",
+          refreshToken: "REFRESH_TOKEN",
+        }),
+      })
+    );
+    expect(onError).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/success/);
+  });
 });
 
 describe("software mfa", () => {


### PR DESCRIPTION
* update mock-generator to perform code regex matching like the real franken-srp generator
* always send a code string to the srp generator for mfa
* add test
